### PR TITLE
Add a new parameter to the scheduler to only perform cross-condition comparisons

### DIFF
--- a/matlab/ASAP/PwcmpASAPScheduler_example.m
+++ b/matlab/ASAP/PwcmpASAPScheduler_example.m
@@ -12,7 +12,7 @@ condition_table = create_factorial_table( scene, method, param );
 % We want to compare relative quality within each scene: comapre all
 % methods at all parameter values with each other, but without any
 % cross-scene comparisons. 
-sch = PwcmpASAPScheduler( 'test_results.csv', 'test_obs', condition_table, { 'scene' } );
+sch = PwcmpASAPScheduler( 'test_results.csv', 'test_obs', condition_table, { 'scene' }, {'method'} );
 
 % To allow for cross-scene comparisons, remove parameter { 'scene' }
 %sch = PwcmpASAPScheduler( 'test_results.csv', 'test_obs', condition_table );

--- a/matlab/ASAP/compute_minimum_spanning_tree.m
+++ b/matlab/ASAP/compute_minimum_spanning_tree.m
@@ -1,7 +1,8 @@
-function [pairs_to_compare] = compute_minimum_spanning_tree(inf_mat)
+function [pairs_to_compare] = compute_minimum_spanning_tree(inf_mat, M_inf)
     % Asap allows for batch mode, for which we return N-1 pairs of conditions for comparisons
     % forming the minimum spanning tree of the 1/information_gain matrix
     inf_mat = inf_mat+inf_mat';
+    inf_mat = inf_mat .* M_inf ; 
     inf_mat = 1./inf_mat;
     inf_mat(inf_mat<0) = Inf;
     GrMST = graph(inf_mat);

--- a/matlab/ASAP/run_asap.m
+++ b/matlab/ASAP/run_asap.m
@@ -1,4 +1,4 @@
-function [pairs_to_compare, Mean, Std] = run_asap(M,mode)
+function [pairs_to_compare, Mean, Std] = run_asap(M, M_inf,mode)
 % Run active sampling for pairwise comaprisons method to find the next pair
 % (or batch of pairs) to compare. 
 %
@@ -46,7 +46,7 @@ function [pairs_to_compare, Mean, Std] = run_asap(M,mode)
     % Compute the information gain matrix and return a single pair maximizing information gain
     [inf_mat,init_data,pairs_to_compare]=compute_information_gain_mat(N,init_data);
     if strcmp(mode,'mst')
-        pairs_to_compare = compute_minimum_spanning_tree(inf_mat);
+        pairs_to_compare = compute_minimum_spanning_tree(inf_mat, M_inf);
     end
     
     Mean = init_data.Ms;


### PR DESCRIPTION
Add a new parameter to the scheduler "block_same_conditions" to only perform cross-condition comparisons. 
The parameter will be used to create a 2D matrix "cmp_inf" for each scene filled with 1 and 0. 1 presents comparisons that should be included (cross-condition comparisons), and 0 which represent comparisons that should not be considered (same-condition comparisons).

The matrix "cmp_inf" will be an input to run_asap, and it will be used in the compute_minimum_spanning_tree function. 
The matrix will be used as a map to the "inf_mat" matrix, so that the comparisons we do not want to consider will be Inf, and we be not included in the results of the spanning tree algorithm. 
